### PR TITLE
Update validation to support comma-seperated emails

### DIFF
--- a/core/core.php
+++ b/core/core.php
@@ -525,8 +525,11 @@ class wsBrokenLinkChecker {
 	        $this->conf->options['send_authors_email_notifications'] = $send_authors_email_notifications;
 
 			$this->conf->options['notification_email_address'] = strval($_POST['notification_email_address']);
-			if ( !filter_var($this->conf->options['notification_email_address'], FILTER_VALIDATE_EMAIL)) {
-				$this->conf->options['notification_email_address'] = '';
+			$notification_email_addresses = explode(',', $this->conf->options['notification_email_address']);
+			foreach ($notification_email_addresses as $notification_email_address) {
+				if ( !filter_var($notification_email_address, FILTER_VALIDATE_EMAIL)) {
+					$this->conf->options['notification_email_address'] = '';
+				}
 			}
 
 	        $widget_cap = strval($_POST['dashboard_widget_capability']);


### PR DESCRIPTION
The wp_mail functionality supports comma-separated emails already so updating the validation to support comma-separated emails allows them to pass through to the mail functionality.

Currently if you provide a comma-separated list of emails it gets emptied upon save.